### PR TITLE
Added the ability to build a remote version

### DIFF
--- a/.env.remote
+++ b/.env.remote
@@ -1,0 +1,2 @@
+# This is the URL pointing to your remote Ampache instance
+VITE_REMOTE_URL=https://YOUR-SERVER-URL

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 public/build/
 dist/
+*.local

--- a/README.md
+++ b/README.md
@@ -47,4 +47,8 @@ Built with [Svelte](https://svelte.dev/) & [wavesurfer.js](https://github.com/ka
 - For development and hot reloading ```npm run dev```
 - For building ```npm run build```
 
+- If you want to use a remote server:
+  - Change ```VITE_REMOTE_URL``` in ```.env.remote``` to your desired server URL
+  - Build with ```npm run build:remote```
+
 Additional console logging can be enabled by setting ```debugMode true``` in ```src/stores/server.js```

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "vite build && npm run copy",
+    "build:remote": "vite build --mode remote && npm run copy",
     "dev": "vite",
     "start": "vite preview",
     "validate": "svelte-check",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -89,7 +89,7 @@
 
 <ThemeHandler />
 
-<Router basepath="{$serverPathname}/ample">
+<Router basepath="{$serverPathname}">
     {#if $isLoggedIn === null && $userToken === null}
         <SiteLoading/>
     {/if}

--- a/src/stores/server.js
+++ b/src/stores/server.js
@@ -31,7 +31,7 @@ export const serverURL = readable(detectedURL, function start(set) {
 
 export const serverPathname = readable(detectedPathname, function start(set) {
     if (import.meta.env.MODE === "remote") {
-        set(detectedURL);
+        set("/");
     } else {
         set(detectedPathname + "/ample");
     }

--- a/src/stores/server.js
+++ b/src/stores/server.js
@@ -21,12 +21,20 @@ export const serverURL = readable(detectedURL, function start(set) {
         // detectedURL = "https://develop.ampache.dev";
     }
 
+    if (import.meta.env.MODE === "remote") {
+        detectedURL = import.meta.env.VITE_REMOTE_URL;
+    }
+
     set(detectedURL);
     return function stop() {};
 });
 
 export const serverPathname = readable(detectedPathname, function start(set) {
-    set(detectedPathname);
+    if (import.meta.env.MODE === "remote") {
+        set(detectedURL);
+    } else {
+        set(detectedPathname + "/ample");
+    }
     return function stop() {};
 });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
     // Default the base path to /ample/ but set it to / if we're using a remote server
     var basePath = "/ample/"
     if (mode === "remote") {
-        basePath = "/";
+        basePath = "/"
     }
 
     return {

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,24 +3,32 @@ import { svelteSVG } from "rollup-plugin-svelte-svg";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import sveltePreprocess from 'svelte-preprocess';
 
-export default defineConfig({
-    base: "/ample/",
+export default defineConfig(({ command, mode, ssrBuild }) => {
+    // Default the base path to /ample/ but set it to / if we're using a remote server
+    var basePath = "/ample/"
+    if (mode === "remote") {
+        basePath = "/";
+    }
 
-    plugins: [
-        svelteSVG({
-            enforce: "pre",
-        }),
+    return {
+        base: basePath,
 
-        svelte({
-            hot: {
-                preserveLocalState: true
-            },
-            preprocess: sveltePreprocess({
-                sourceMap: false,
-                postcss: {
-                    plugins: [require('autoprefixer')()]
-                }
+        plugins: [
+            svelteSVG({
+                enforce: "pre",
             }),
-        })
-    ]
+
+            svelte({
+                hot: {
+                    preserveLocalState: true
+                },
+                preprocess: sveltePreprocess({
+                    sourceMap: false,
+                    postcss: {
+                        plugins: [require('autoprefixer')()]
+                    }
+                }),
+            })
+        ]
+    }
 });


### PR DESCRIPTION
This version doesn't require being in the same directory as Ampache.
To use a remote server you can just set the URL in the ```.env.remote``` file and then run ```npm run build:remote```